### PR TITLE
fix(api): restore guardrail semantics and expand kind schema to all c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,16 @@ cat .out/week-5/scheduler_manifest.csv
 Small, conservative guardrails are applied to generated scripts:
 
 - `GUARDRAILS_LENGTH_MODE` — how length violations are handled:
-  - `fail` (default): API responds 400 when script > 70 words
+  - `fail` (default): API responds 422 when script > 70 words
   - `trim`: API trims to 70 words automatically
 - CLI flag: `--strict` / `--no-strict` — `--strict` requests fail-on-long, `--no-strict` requests auto-trim
 - Player blocking: Data Agent returns `blocked: True` for OUT/IR players and the API responds with HTTP 400 and `block_reason`.
+
+### Strict vs trim length enforcement
+
+- API requests default to *strict* mode (`fail`). Provide `X-Guardrails-Strict: false` to switch a request into trim mode and receive a 200 response with a shortened script when it exceeds 70 words.
+- The `ff-post` CLI propagates this header for you: `--strict` keeps fail-fast semantics; `--no-strict` sends `X-Guardrails-Strict: false`.
+- Guardrail violations now return HTTP 422 with an explanatory `detail`, making it easier to branch on failures in operators or tests.
 
 Examples:
 

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -4,49 +4,73 @@ Pydantic schemas for Fantasy TikTok Engine API.
 Defines request/response models for API endpoints with validation.
 """
 
-from typing import Literal
+from typing import Literal, Tuple
 from pydantic import BaseModel, Field
+
+# Canonical list of PRD-supported content kinds (20 total)
+PRD_CONTENT_KINDS: Tuple[str, ...] = (
+    "start-sit",
+    "waiver-wire",
+    "injury-pivot",
+    "trade-thermometer",
+    "top-performers",
+    "biggest-busts",
+    "breakout-tracker",
+    "injury-report-rundowns",
+    "coaching-playcalling-changes",
+    "depth-chart-shifts",
+    "suspension-return-watch",
+    "rest-of-season-outlooks",
+    "matchup-exploits",
+    "playoff-prep",
+    "usage-trends",
+    "consistency-kings",
+    "fantasy-awards-memes",
+    "polls-hot-takes",
+    "qna-replies",
+    "weekly-wraps-previews",
+)
 
 
 class GenerateRequest(BaseModel):
     """Request model for content generation endpoint."""
-    
+
     player: str = Field(..., description="Fantasy football player name", min_length=1)
     week: int = Field(..., description="NFL week number", ge=1, le=18)
-    kind: Literal["start-sit", "waiver-wire", "injury-pivot", "trade-thermometer"] = Field(
+    kind: Literal[*PRD_CONTENT_KINDS] = Field(
         ..., description="Type of content to generate"
     )
-    
+
     class Config:
         schema_extra = {
             "example": {
                 "player": "Bijan Robinson",
                 "week": 5,
-                "kind": "start-sit"
+                "kind": "start-sit",
             }
         }
 
 
 class GenerateResponse(BaseModel):
     """Response model for content generation endpoint."""
-    
+
     ok: bool = Field(..., description="Whether the generation was successful")
     script: str = Field(..., description="Generated content script")
-    
+
     class Config:
         schema_extra = {
             "example": {
                 "ok": True,
-                "script": "🔥 **WEEK 5 START/SIT ALERT** 🔥\n\nShould you start **Bijan Robinson** this week?"
+                "script": "🔥 **WEEK 5 START/SIT ALERT** 🔥\n\nShould you start **Bijan Robinson** this week?",
             }
         }
 
 
 class HealthResponse(BaseModel):
     """Response model for health check endpoint."""
-    
+
     status: str = Field(..., description="Service health status")
-    
+
     class Config:
         schema_extra = {
             "example": {
@@ -57,9 +81,9 @@ class HealthResponse(BaseModel):
 
 class VersionResponse(BaseModel):
     """Response model for version endpoint."""
-    
+
     version: str = Field(..., description="API version")
-    
+
     class Config:
         schema_extra = {
             "example": {

--- a/tests/test_api_guardrails.py
+++ b/tests/test_api_guardrails.py
@@ -1,0 +1,70 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+def _long_script() -> str:
+    return " ".join([f"word{i}" for i in range(1, 101)])  # 100 words
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_trim_mode_returns_200(monkeypatch, client):
+    monkeypatch.setattr(
+        "apps.api.main.fetch_player_context",
+        lambda player, week, kind: {"player": player, "week": week, "kind": kind},
+    )
+    monkeypatch.setattr(
+        "apps.api.main.render_script",
+        lambda kind, context, template_path: _long_script(),
+    )
+
+    response = client.post(
+        "/generate",
+        headers={"X-Guardrails-Strict": "false"},
+        json={"player": "Test Player", "week": 5, "kind": "waiver-wire"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert len(payload["script"].split()) == 70
+
+
+def test_strict_mode_returns_422(monkeypatch, client):
+    monkeypatch.setattr(
+        "apps.api.main.fetch_player_context",
+        lambda player, week, kind: {"player": player, "week": week, "kind": kind},
+    )
+    monkeypatch.setattr(
+        "apps.api.main.render_script",
+        lambda kind, context, template_path: _long_script(),
+    )
+
+    response = client.post(
+        "/generate",
+        json={"player": "Test Player", "week": 5, "kind": "waiver-wire"},
+    )
+
+    assert response.status_code == 422
+    assert "Guardrail failed" in response.json().get("detail", "")
+
+
+def test_http_exception_passthrough(monkeypatch, client):
+    def _raise_http_exception(*_args, **_kwargs):
+        raise HTTPException(status_code=409, detail="blocked by upstream")
+
+    monkeypatch.setattr("apps.api.main.fetch_player_context", _raise_http_exception)
+
+    response = client.post(
+        "/generate",
+        json={"player": "Test Player", "week": 5, "kind": "waiver-wire"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "blocked by upstream"


### PR DESCRIPTION
…ategories

- fix(api): preserve HTTPException codes within generate_content
  - Preserve specific HTTP status codes (409 for blocked, 422 for validation)
  - Catch HTTPException separately to avoid wrapping in generic 500 errors
  - Add proper status code imports and structured error handling

- feat(api): expand GenerateRequest.kind Literal to 20 slugs
  - Add PRD_CONTENT_KINDS tuple with all 20 supported content types
  - Update GenerateRequest.kind to use Literal[*PRD_CONTENT_KINDS]
  - Improve template resolution with fallback logic for both locations

- feat(cli): forward --no-strict as X-Guardrails-Strict header
  - Add X-Guardrails-Strict header support in CLI
  - Normalize kind aliases and validation against PRD_CONTENT_KINDS
  - Improve error handling and user experience

- test(api): cover strict vs trim and status passthrough
  - Add comprehensive test suite for API guardrails
  - Test HTTP status code preservation and header handling

## What

Brief description of the changes in this PR.

## Why

Explain the motivation for these changes. What problem does this solve?

## How

Describe the technical approach and key implementation details.

## Tested

- [ ] Unit tests pass (`make test`)
- [ ] API health check passes (`make health`)
- [ ] Manual testing completed
- [ ] Code formatted and linted (`make fmt && make lint`)

Testing details:
- Manual testing: [describe what you tested]
- Edge cases considered: [list any edge cases]

## Risks

What are the potential risks of this change?
- [ ] Breaking changes to API
- [ ] Database schema changes
- [ ] Performance impact
- [ ] Security implications

## Rollback Plan

How would you rollback this change if needed?

## Additional Notes

Any other context, screenshots, or information reviewers should know.